### PR TITLE
Fix duplicate labels in manual

### DIFF
--- a/doc/functionality.xml
+++ b/doc/functionality.xml
@@ -673,7 +673,7 @@ function requires the package &specht; (see <Ref Func="LoadPackage" BookName="Re
 </Description>
 </ManSection>
 <!--######################################################################-->
-<ManSection Label="DecompositionNumber">
+<ManSection>
 <Meth Name="DecompositionNumber" Arg="H, mu, nu"/>
 <Meth Name="DecompositionNumber" Label="for a decomposition matrix"
   Arg="d, mu, nu"/>


### PR DESCRIPTION
Removed the label `DecompositionNumber` on a ManSection, since the exact same label is generated by the method with the same name just below.